### PR TITLE
Fix aggregate class definition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ group :development do
   gem 'rake'
   gem 'jeweler'
   gem 'rspec', '>= 2.2.0'
-  gem 'mocha'
+  gem 'mocha', '0.11.0'
 end

--- a/lib/trackoid/aggregates.rb
+++ b/lib/trackoid/aggregates.rb
@@ -132,7 +132,8 @@ module Mongoid  #:nodoc:
         def define_klass(&block)
           scope = internal_aggregates_name.split('::')
           klass = scope.pop
-          klass = Object.const_set(klass, Class.new)
+          scope = scope.inject(Object) {|scope, const_name| scope.const_get(const_name)}
+          klass = scope.const_set(klass, Class.new)
           klass.class_eval(&block)
         end
 

--- a/lib/trackoid/aggregates.rb
+++ b/lib/trackoid/aggregates.rb
@@ -132,8 +132,7 @@ module Mongoid  #:nodoc:
         def define_klass(&block)
           scope = internal_aggregates_name.split('::')
           klass = scope.pop
-          scope = scope.inject(Kernel) {|scope, const_name| scope.const_get(const_name)}
-          klass = scope.const_set(klass, Class.new)
+          klass = Object.const_set(klass, Class.new)
           klass.class_eval(&block)
         end
 

--- a/lib/trackoid/tracking.rb
+++ b/lib/trackoid/tracking.rb
@@ -7,8 +7,10 @@ module Mongoid #:nodoc:
     # field named after :field
     def self.included(base)
       base.class_eval do
-        raise Errors::NotMongoid, "Must be included in a Mongoid::Document" unless self.ancestors.include? Mongoid::Document
-
+        unless self.ancestors.include? Mongoid::Document
+          raise Errors::NotMongoid, "Must be included in a Mongoid::Document"
+        end
+        
         include Aggregates
         extend ClassMethods
         

--- a/spec/aggregates_spec.rb
+++ b/spec/aggregates_spec.rb
@@ -7,7 +7,7 @@ class TestModel
   field :name   # Dummy field
 
   # Note that references to "track" and "aggregate" in this test are mixed
-  # for testing pourposes. Trackoid does not make any difference in the
+  # for testing purposes. Trackoid does not make any difference in the
   # declaration order of tracking fields and aggregate tokens.
   track :visits
   aggregate :browsers do |b| b.split.first.downcase if b; end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,8 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'rubygems'
 
-gem 'mocha', '>= 0.9.8'
+# What is this doing here?
+# gem 'mocha', '>= 0.9.8'
 
 require 'mocha'
 require 'mongoid'

--- a/spec/trackoid_spec.rb
+++ b/spec/trackoid_spec.rb
@@ -70,7 +70,7 @@ describe Mongoid::Tracking do
 
     it "should respond 'false' to field_changed? method" do
       # Ok, this test is not very relevant since it will return false even
-      # if Trackid does not override it.
+      # if Trackoid does not override it.
       @mock.visits_changed?.should be_false
     end
 
@@ -93,7 +93,7 @@ describe Mongoid::Tracking do
       lambda { @mock.visits.inc }.should raise_error Mongoid::Errors::ModelNotSaved
     end
 
-    it "shold create an empty hash as the internal representation" do
+    it "should create an empty hash as the internal representation" do
       @mock.visits.send(:_original_hash).should == {}
     end
 

--- a/trackoid.gemspec
+++ b/trackoid.gemspec
@@ -60,20 +60,20 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<rake>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
       s.add_development_dependency(%q<rspec>, [">= 2.2.0"])
-      s.add_development_dependency(%q<mocha>, [">= 0"])
+      s.add_development_dependency(%q<mocha>, ["~> 0.10.0"])
     else
       s.add_dependency(%q<mongoid>, [">= 2.1.0"])
       s.add_dependency(%q<rake>, [">= 0"])
       s.add_dependency(%q<jeweler>, [">= 0"])
       s.add_dependency(%q<rspec>, [">= 2.2.0"])
-      s.add_dependency(%q<mocha>, [">= 0"])
+      s.add_dependency(%q<mocha>, ["~> 0.10.0"])
     end
   else
     s.add_dependency(%q<mongoid>, [">= 2.1.0"])
     s.add_dependency(%q<rake>, [">= 0"])
     s.add_dependency(%q<jeweler>, [">= 0"])
     s.add_dependency(%q<rspec>, [">= 2.2.0"])
-    s.add_dependency(%q<mocha>, [">= 0"])
+    s.add_dependency(%q<mocha>, ["~> 0.10.0"])
   end
 end
 


### PR DESCRIPTION
This fixes the problem described in #17.
Specs passes and I guess it's ok to do it this way?
Could you please explain what this line is doing?

```
scope = scope.inject(Kernel) {|scope, const_name| scope.const_get(const_name)}
```

Thanks!
