### PR TITLE
Updated Gemspec to allow newer versions of Mongoid

### DIFF
--- a/trackoid.gemspec
+++ b/trackoid.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 
-  s.add_dependency 'mongoid', '~> 3.0.5'
+  s.add_dependency 'mongoid', '~> 3.1.2'
   s.add_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'mocha'


### PR DESCRIPTION
Some features like as TTL in documents are only available in newer
version of Mongoid (3.1.2 in my case), so update Trackoid's gemspec to don't generate conflicts with versions.
